### PR TITLE
Issue-21 Store warehouse data to local file

### DIFF
--- a/brains.py
+++ b/brains.py
@@ -167,17 +167,22 @@ def main(update, context):
         command.append('</code>')
         return ''.join(command)
 
+    def warehouse_load_saved(ignore_exceptions):
+        try:
+            with open('warehouse.dict', 'rb') as warehouseFile:
+                return pickle.load(warehouseFile)
+        except IOError:
+            if not ignore_exceptions:
+                raise
+            else:
+                return {} # Ignore if warehouse.dict doesn't exist or can't be opened.
+
     def warehouse_in():
         if not hasattr(update.message.forward_from, 'id') or update.message.forward_from.id not in [408101137]: # @chtwrsbot
             ret.append('Must be a forward from @chtwrsbot. Try again.')
         else:
             now = update.message.forward_date
-            warehouse = {}
-            try:
-                with open('warehouse.dict', 'rb') as warehouseFile:
-                    warehouse = pickle.load(warehouseFile)
-            except IOError:
-                pass # Ignore if warehouse.dict doesn't exist or can't be opened.
+            warehouse = warehouse_load_saved(True)
             data = {}
             for row in text.split('\n')[1:]:
                 s = row.split()
@@ -240,7 +245,7 @@ def main(update, context):
     return ret
 
 def warehouse_crafting(context):
-    warehouse = context.user_data.get('warehouse', {})
+    warehouse = warehouse_load_saved(True)
     hours = 2
     responses = []
     now = datetime.datetime.utcnow()

--- a/brains.py
+++ b/brains.py
@@ -172,7 +172,12 @@ def main(update, context):
             ret.append('Must be a forward from @chtwrsbot. Try again.')
         else:
             now = update.message.forward_date
-            warehouse = context.user_data.get('warehouse', {})
+            warehouse = {}
+            try:
+                with open('warehouse.dict', 'rb') as warehouseFile:
+                    warehouse = pickle.load(warehouseFile)
+            except IOError:
+                pass # Ignore if warehouse.dict doesn't exist or can't be opened.
             data = {}
             for row in text.split('\n')[1:]:
                 s = row.split()
@@ -195,7 +200,8 @@ def main(update, context):
 
             if not warehouse.get(key) or now > warehouse[key].get('timestamp', datetime.datetime.min):
                 warehouse[key] = {'timestamp': now, 'data': data}
-                context.user_data['warehouse'] = warehouse
+                with open('warehouse.dict', 'wb') as warehouseFile
+                    pickle.dump(warehouse, warehouseFile)
                 ret.append(key)
             else:
                 ret.append(f'{key}, but not newer than data on file')
@@ -548,3 +554,4 @@ if __name__ == '__main__':
     #              '448 x 9💰 [Selling] /rm_blrd58fqqm6kjt667chg\n'
     #              '\n'
     #              'Your last 10 comitted trades: /trades',
+


### PR DESCRIPTION
* To have data access across all users, we must use local storage rather
  than depend on CW APIs for storage.
* This pickles the CW warehouse data, storing it into warehouse.dict
  file.
* If no warehouse.dict file found, one is created.